### PR TITLE
feat: Added expense logging with optional category functionality

### DIFF
--- a/src/main/java/com/lobanmating/budget_api/controller/ExpenseController.java
+++ b/src/main/java/com/lobanmating/budget_api/controller/ExpenseController.java
@@ -1,0 +1,44 @@
+package com.lobanmating.budget_api.controller;
+
+import com.lobanmating.budget_api.dto.ExpenseRequest;
+import com.lobanmating.budget_api.model.Expense;
+import com.lobanmating.budget_api.service.ExpenseService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/expenses")
+public class ExpenseController {
+    private final ExpenseService expenseService;
+
+    public ExpenseController(ExpenseService expenseService) {
+        this.expenseService = expenseService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Expense> createExpense(@Valid @RequestBody ExpenseRequest expenseRequest) {
+        expenseService.createExpense(expenseRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Expense>> getExpenses(@RequestParam(required = false) String category) {
+        List<Expense> expenses;
+        if (category == null) {
+            expenses = expenseService.getAllExpenses();
+        } else {
+            expenses = expenseService.getExpensesByCategory(category);
+        }
+        return ResponseEntity.ok(expenses);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteExpenseById(@PathVariable Long id) {
+        expenseService.deleteExpenseById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/lobanmating/budget_api/controller/UserController.java
+++ b/src/main/java/com/lobanmating/budget_api/controller/UserController.java
@@ -12,6 +12,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/users")
 public class UserController {
+
+    // TODO: return resopnse entities for all to have more flexibility with return codes
     private final UserService userService;
 
     public UserController(UserService userService) {

--- a/src/main/java/com/lobanmating/budget_api/dto/ExpenseRequest.java
+++ b/src/main/java/com/lobanmating/budget_api/dto/ExpenseRequest.java
@@ -1,0 +1,31 @@
+package com.lobanmating.budget_api.dto;
+
+import com.lobanmating.budget_api.model.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@ToString
+// Do not include user ID so that it cannot be manipulated through malicious JSON inputs
+public class ExpenseRequest {
+
+    @NotBlank(message = "Name is required")
+    private String title;
+
+    @NotNull(message = "Amount is required")
+    @Positive(message = "Amount must be positive")
+    private BigDecimal amount;
+
+    String category;
+
+    @PastOrPresent(message = "Date cannot be in the future")
+    @NotNull(message = "Date is required")
+    private LocalDate date;
+}

--- a/src/main/java/com/lobanmating/budget_api/model/Expense.java
+++ b/src/main/java/com/lobanmating/budget_api/model/Expense.java
@@ -1,0 +1,36 @@
+package com.lobanmating.budget_api.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+@Data
+@ToString(exclude = "user")
+@Table(name = "expenses")
+public class Expense {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/lobanmating/budget_api/model/User.java
+++ b/src/main/java/com/lobanmating/budget_api/model/User.java
@@ -25,4 +25,11 @@ public class User {
         this.email = email;
         this.password = password;
     }
+
+    // Factory method to create user with only id
+    public static User withId(Long id) {
+        User user = new User();
+        user.id = id;
+        return user;
+    }
 }

--- a/src/main/java/com/lobanmating/budget_api/repository/ExpenseRepository.java
+++ b/src/main/java/com/lobanmating/budget_api/repository/ExpenseRepository.java
@@ -1,0 +1,13 @@
+package com.lobanmating.budget_api.repository;
+
+import com.lobanmating.budget_api.model.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    List<Expense> findByUserId(Long userId);
+    List<Expense> findByUserIdAndCategory(Long userId, String category);
+}

--- a/src/main/java/com/lobanmating/budget_api/security/CustomUserDetails.java
+++ b/src/main/java/com/lobanmating/budget_api/security/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package com.lobanmating.budget_api.security;
+
+import com.lobanmating.budget_api.model.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    @Getter
+    private Long id;
+    private final String email;
+    private final String password;
+
+    public CustomUserDetails(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/lobanmating/budget_api/security/JwtUtil.java
+++ b/src/main/java/com/lobanmating/budget_api/security/JwtUtil.java
@@ -25,6 +25,7 @@ public class JwtUtil {
         return Keys.hmacShaKeyFor(keyBytes);
     }
 
+    // TODO: add search by user id functionality for lightweight searching without making db calls
     public String generateToken(String email) {
         return Jwts.builder()
                 .setSubject(email)

--- a/src/main/java/com/lobanmating/budget_api/service/CustomUserDetailsService.java
+++ b/src/main/java/com/lobanmating/budget_api/service/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package com.lobanmating.budget_api.service;
 
 import com.lobanmating.budget_api.model.User;
 import com.lobanmating.budget_api.repository.UserRepository;
+import com.lobanmating.budget_api.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -17,15 +18,11 @@ public class CustomUserDetailsService implements UserDetailsService {
     private UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User with the following email not found: " + email));
 
-        return new org.springframework.security.core.userdetails.User(
-                user.getEmail(),
-                user.getPassword(),
-                // TODO: add authorities for users in the future
-                new ArrayList<>()
-        );
+        // TODO: add authorities for users in the future
+        return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/lobanmating/budget_api/service/ExpenseService.java
+++ b/src/main/java/com/lobanmating/budget_api/service/ExpenseService.java
@@ -1,0 +1,66 @@
+package com.lobanmating.budget_api.service;
+
+import com.lobanmating.budget_api.dto.ExpenseRequest;
+import com.lobanmating.budget_api.model.Expense;
+import com.lobanmating.budget_api.model.User;
+import com.lobanmating.budget_api.repository.ExpenseRepository;
+import com.lobanmating.budget_api.security.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+
+    public ExpenseService(ExpenseRepository expenseRepository) {
+        this.expenseRepository = expenseRepository;
+    }
+
+    public void createExpense(ExpenseRequest expenseRequest) {
+        // Account for category being an optional field
+        String category = expenseRequest.getCategory();
+        if (category == null || category.isBlank()) {
+            category = "N/A";
+        }
+
+        Expense expense = Expense.builder()
+                .title(expenseRequest.getTitle())
+                .amount(expenseRequest.getAmount())
+                .category(category)
+                .date(expenseRequest.getDate())
+                .user(User.withId(getCurrentUserId()))
+                .build();
+
+        expenseRepository.save(expense);
+    }
+
+    public List<Expense> getAllExpenses() {
+        // Identify user id through authentication context to avoid additional db calls
+        return expenseRepository.findByUserId(getCurrentUserId());
+    }
+
+    public List<Expense> getExpensesByCategory(String category) {
+        return expenseRepository.findByUserIdAndCategory(getCurrentUserId(), category);
+    }
+
+    public void deleteExpenseById(Long id) {
+        Long userId = getCurrentUserId();
+        Expense expense = expenseRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Expense not found"));
+        if (!expense.getUser().getId().equals(userId)) {
+            throw new SecurityException("Not authorized to delete this expense");
+        }
+        expenseRepository.deleteById(id);
+    }
+
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+        return userDetails.getId();
+    }
+
+}


### PR DESCRIPTION
## Summary

Implements expense logging functionality through secure API endpoints. Each expense is associated with the authenticated user, and includes support for an optional `category` field. All endpoints are protected and require a valid JWT token for access.

---

## Changes Made

### Expenses
- Created a new `Expense` entity mapped to the `expenses` table in PostgreSQL, with fields for `title`, `amount`, `category`, `date`, and a foreign key reference to the authenticated `User`.
- Added `ExpenseRequest` DTO to process incoming JSON request payloads, with validation annotations and defaulting logic for optional `category` field.
- Implemented `ExpenseRepository` with custom methods:
  - `findByUserId(Long userId)`
  - `findByUserIdAndCategory(Long userId, String category)`
- Developed `ExpenseService` to handle all business logic:
  - Creating, retrieving, and deleting expenses for the current user
  - Injecting user ID from Spring Security context to avoid additional DB lookups
- Created `ExpenseController` to expose RESTful endpoints for expense management
- Extended Spring Security’s `UserDetails` with `CustomUserDetails` to store user ID in the security context and simplify downstream access

---

## API Endpoints Added

| Method | Endpoint           | Description                                                             |
|--------|--------------------|-------------------------------------------------------------------------|
| POST   | `/expenses`        | Creates an expense for the authenticated user                           |
| GET    | `/expenses`        | Retrieves all expenses belonging to the authenticated user              |
| GET    | `/expenses?category=...` | Retrieves expenses by category for the authenticated user        |
| DELETE | `/expenses/{id}`   | Deletes an expense by ID (if it belongs to the authenticated user)      |

> All endpoints are protected and require a valid JWT token in the `Authorization: Bearer <token>` header.

---

## Testing

### Manual Testing via Postman:
- ✅ Created new expenses with and without a category
- ✅ Retrieved all expenses for the logged-in user
- ✅ Retrieved filtered expenses by category
- ✅ Successfully deleted expenses by ID
- ✅ Verified that only the user's own expenses can be accessed or deleted

### Edge Cases Tested:
- Omitted or blank `category` defaults to `"N/A"`
- Unauthorized access returns 401 or 403 as appropriate
- Invalid or expired JWT tokens rejected
- Deletion attempt on another user’s expense correctly blocked
- Validation errors (e.g., negative amounts, missing title/date) return appropriate 400 responses

---

## Security Considerations
- All expense endpoints require authentication via JWT
- Only the owner of an expense can retrieve or delete it
- Passwords are securely hashed using BCrypt (as implemented in user authentication flow)
- CSRF protection is disabled due to the stateless nature of JWT
- CORS configured to allow client-side applications to interact with the API

---

## Future Enhancements
- Add update (`PUT`) endpoint to modify an existing expense
- Support pagination and sorting on expense retrieval
- Implement filtering by date range
- Add total summary calculation for expenses by month/category
- Implement soft delete (e.g., mark as inactive instead of permanent deletion)
- Enhance validation rules (e.g., max title length)

---

## Breaking Changes
None — this is a new feature. Existing endpoints and user flows remain unaffected.
